### PR TITLE
Property 'spring.datasource.initialization-mode' is deprecated: Use 'spring.sql.init.mode' instead

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -4,6 +4,8 @@ spring:
     url: jdbc:postgresql://localhost:5432/Zikken
     username: ${DB_USER:postgres}
     password: ${DB_PASS:postgres}
-    initialization-mode: always
     schema: classpath:schema.sql
     data: classpath:data.sql
+  sql:
+    init:
+      mode: always


### PR DESCRIPTION
Update deprecated property in `application.yml`

* Replace `spring.datasource.initialization-mode` with `spring.sql.init.mode`
* Ensure the value remains `always`

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/yoshikawa260/zikken?shareId=1bd1b82c-579f-46cb-b7b4-5a7ea246786d).